### PR TITLE
feat: adds book icon and libby link

### DIFF
--- a/src/components/Book.tsx
+++ b/src/components/Book.tsx
@@ -2,6 +2,7 @@ import { Card } from "antd";
 import IBook from "../types/IBook";
 import FavoriteIcon from "./FavoriteIcon";
 import DislikeIcon from "./DislikeIcon";
+import LibbyIcon from "./LibbyIcon";
 
 interface IProps {
   book: IBook;
@@ -23,6 +24,7 @@ const Book = ({ book }: IProps) => {
                 <span className="Book-icon">
                   {book.best_of && <FavoriteIcon />}
                   {book.worst_of && <DislikeIcon />}
+                  {book.libby_link && <a href={book.libby_link} target="_blank"><LibbyIcon/></a>}
                 </span>
                 {book.title}
               </div>

--- a/src/components/LibbyIcon.tsx
+++ b/src/components/LibbyIcon.tsx
@@ -1,0 +1,9 @@
+import {BookFilled} from "@ant-design/icons";
+
+const LibbyIcon = () => {
+  return (
+      <BookFilled style={{color: '#A61C49', marginRight: 5}} />
+  );
+};
+
+export default LibbyIcon;

--- a/src/types/IBook.ts
+++ b/src/types/IBook.ts
@@ -27,6 +27,7 @@ export default interface IBook {
   worst_of: boolean;
   year_published: number;
   goodreads_link: string;
+  libby_link: string;
   image: string;
   genres: string[];
   picked_by?: string;


### PR DESCRIPTION
Adding libby_link to Google Sheets book references will allow a book icon to show up on the Book component with a link to Libby

Example of a Libby Link https://share.libbyapp.com/title/5999223

<img width="254" alt="image" src="https://github.com/mknabe/book-club/assets/8963376/f51b1aef-341f-411c-a159-018c0a089926">
